### PR TITLE
カメラ許可とキャンパス選択のモーダルがかぶらないように変更

### DIFF
--- a/components/QrCode.tsx
+++ b/components/QrCode.tsx
@@ -19,7 +19,9 @@ import {
   useCameraState,
   cameraComponentState,
   qrDataState,
+  campusState,
 } from '../utils/recoilAtoms';
+import {Campus} from '../@types/campus';
 import * as colors from '../utils/colors';
 
 const QrTitle = ({text}: {text: string}) => (
@@ -84,6 +86,7 @@ const Qr = () => {
   const [isQrLoad] = useRecoilState(qrLoadState);
   const [useCamera] = useRecoilState(useCameraState);
   const [qrData] = useRecoilState(qrDataState);
+  const [isCampus] = useRecoilState(campusState);
   const [cameraComponent, setCameraComponent] = useRecoilState(
     cameraComponentState
   );
@@ -115,7 +118,7 @@ const Qr = () => {
       >
         {qrStatus(isQrLoad, useCamera, isQrRead)}
         <Box position="absolute" zIndex="0" borderRadius="2rem" width="100%">
-          {cameraComponent ? <QrReader /> : null}
+          {cameraComponent && isCampus !== Campus.null ? <QrReader /> : null}
         </Box>
       </Box>
     </AspectRatio>


### PR DESCRIPTION
キャンパス選択のモーダルの上に、カメラ使用許可のダイアログが出てしまい見栄え的によろしくなかったため、
キャンパス選択が終わるまではカメラの使用許可は求めないように変更しました。