### PR TITLE
toastで読み取った文が長い場合に画面外に出てしまう問題の修正

### DIFF
--- a/components/QrCode.tsx
+++ b/components/QrCode.tsx
@@ -98,7 +98,7 @@ const Qr = () => {
     if (isQrRead) {
       toast({
         title: '読み取り完了',
-        description: qrData,
+        description: <Text wordBreak="break-all">{qrData}</Text>,
         status: 'success',
         duration: 4000,
         isClosable: true,


### PR DESCRIPTION
`word-break: break-all;` 属性の追加。